### PR TITLE
Add mysql innodb cfg to fix issue #32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ADD supporting_files/run.sh /run.sh
 RUN chmod 755 /*.sh
 ADD supporting_files/supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
 ADD supporting_files/supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+ADD supporting_files/mysqld_innodb.cnf /etc/mysql/conf.d/mysqld_innodb.cnf
 
 # Set PHP timezones to Europe/London
 RUN sed -i "s/;date.timezone =/date.timezone = Europe\/London/g" /etc/php/5.6/apache2/php.ini

--- a/Dockerfile1404
+++ b/Dockerfile1404
@@ -43,6 +43,7 @@ ADD supporting_files/run.sh /run.sh
 RUN chmod 755 /*.sh
 ADD supporting_files/supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
 ADD supporting_files/supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+ADD supporting_files/mysqld_innodb.cnf /etc/mysql/conf.d/mysqld_innodb.cnf
 
 # Set PHP timezones to Europe/London
 RUN sed -i "s/;date.timezone =/date.timezone = Europe\/London/g" /etc/php/5.6/apache2/php.ini

--- a/supporting_files/mysqld_innodb.cnf
+++ b/supporting_files/mysqld_innodb.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+server-id=1
+innodb_flush_method=O_DSYNC
+innodb-use-native-aio=0
+log_bin=ON

--- a/tests/expected/1404.html
+++ b/tests/expected/1404.html
@@ -44,8 +44,8 @@
             <pre>
 OS: Linux<br/>
 Apache: Apache/2.4.7 (Ubuntu)<br/>
-MySQL Version: 5.5.58-0ubuntu0.14.04.1<br/>
-PHP Version: 5.6.33-1+ubuntu14.04.1+deb.sury.org+1<br/>
+MySQL Version: 5.5.60-0ubuntu0.14.04.1-log<br/>
+PHP Version: 5.6.36-1+ubuntu14.04.1+deb.sury.org+1<br/>
 phpMyAdmin Version: 4.7.7<span>&nbsp;</span>
             </pre>
         </section>

--- a/tests/expected/1604.html
+++ b/tests/expected/1604.html
@@ -44,8 +44,8 @@
             <pre>
 OS: Linux<br/>
 Apache: Apache/2.4.18 (Ubuntu)<br/>
-MySQL Version: 5.7.20-0ubuntu0.16.04.1<br/>
-PHP Version: 5.6.33-1+ubuntu16.04.1+deb.sury.org+1<br/>
+MySQL Version: 5.7.22-0ubuntu0.16.04.1-log<br/>
+PHP Version: 5.6.36-1+ubuntu16.04.1+deb.sury.org+1<br/>
 phpMyAdmin Version: 4.7.7<span>&nbsp;</span>
             </pre>
         </section>


### PR DESCRIPTION
When mapping the container's MySQL folder to a local drive on Windows 10,
Docker Toolbox, and VirtualBox, I get errors at MySQL startup.

A solution for this is outlined here:
https://github.com/boot2docker/boot2docker/issues/1300

With this change, I'm adding the innodb config referenced there.

A few additional notes:

1. In MySQL 5.7, the `server-id` setting is required when enabling binary
   logging; before adding this, MySQL would fail on startup.

2. I was unable to run the tests completely; it seems in daemon mode, the ports
   aren't getting mapped properly; running `bash` on the container, I could
   make a localhost call successfully.

3. Apache, PHP, MySQL versions all bumped when I built the new image; I updated
   the tests to match the versions in the new image.