### PR TITLE
Fix the version numbers of phusion/baseimage 1604 1804

### DIFF
--- a/1604/Dockerfile
+++ b/1604/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:0.10.2
 MAINTAINER Matthew Rayner <hello@rayner.io>
 ENV REFRESHED_AT 2019-03-12
 

--- a/1804/Dockerfile
+++ b/1804/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:0.11
 MAINTAINER Matthew Rayner <hello@rayner.io>
 ENV REFRESHED_AT 2019-03-12
 


### PR DESCRIPTION
From #59 .

<br>

Furthermore, I don't know whether this line in Dockerfile.test needs to be modified: 

https://github.com/mattrayner/docker-lamp/blob/daef7079c4f082c85d7593c25657d758a5cc01c6/tests/Dockerfile.test#L1