### PR TITLE
Remove redundant mysqld bind-address config

### DIFF
--- a/supporting_files/mysqld_innodb.cnf
+++ b/supporting_files/mysqld_innodb.cnf
@@ -3,4 +3,3 @@ server-id=1
 innodb_flush_method=O_DSYNC
 innodb-use-native-aio=0
 log_bin=ON
-bind-address=0.0.0.0

--- a/supporting_files/run.sh
+++ b/supporting_files/run.sh
@@ -42,7 +42,6 @@ fi
 
 rm /var/run/mysqld/mysqld.sock
 
-sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
 sed -i "s/user.*/user = www-data/" /etc/mysql/my.cnf
 
 if [[ ! -d $VOLUME_HOME/mysql ]]; then


### PR DESCRIPTION
Related to #47 and #63 .

The `bind-address` config in `/etc/mysql/conf.d/mysqld_innodb.cnf` has been overridden by `/etc/mysql/mysql.conf.d/mysqld.cnf` because of the `includedir` order in `/etc/mysql/mysql.cnf`.

``` conf
!includedir /etc/mysql/conf.d/
!includedir /etc/mysql/mysql.conf.d/
```