### PR TITLE
Let 'supervisord' use 'pidproxy' to run 'mysqld'

### DIFF
--- a/supporting_files/start-mysqld.sh
+++ b/supporting_files/start-mysqld.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec mysqld_safe
+exec /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe


### PR DESCRIPTION
Hi. I found that `mysqld` will prevent the container from shutting down and the container will be killed by docker since the time-out. The log looks like this.

```
2020-06-11 13:58:39,010 WARN received SIGINT indicating exit request
2020-06-11 13:58:39,036 INFO waiting for mysqld, apache2 to die
2020-06-11 13:58:39,109 INFO stopped: apache2 (exit status 0)
2020-06-11 13:58:42,113 INFO waiting for mysqld to die
2020-06-11 13:58:45,117 INFO waiting for mysqld to die
2020-06-11 13:58:48,121 INFO waiting for mysqld to die
2020-06-11 13:58:49,122 WARN killing 'mysqld' (503) with SIGKILL
2020-06-11 13:58:49,123 INFO stopped: mysqld (terminated by SIGKILL)
```

As [Subprocesses &mdash; Supervisor 4.2.0 documentation](http://supervisord.org/subprocess.html?#pidproxy-program) said, `supervisord` cannot kill `mysqld`. So we should use the new command. And now, `mysqld` and the container can be shutdown gracefully.

```
2020-06-11 14:06:32,677 WARN received SIGINT indicating exit request
2020-06-11 14:06:32,881 INFO waiting for mysqld, apache2 to die
2020-06-11 14:06:32,981 INFO stopped: apache2 (exit status 0)
2020-06-11 14:06:32,996 INFO stopped: mysqld (exit status 0)
```

---

Emm, I believe that this commit is heading to the `docker-lamp/HEAD`. 😅