### PR TITLE
Check the status of Apache and MySQL through "supervisorctl"

### DIFF
--- a/1604/Dockerfile
+++ b/1604/Dockerfile
@@ -12,6 +12,7 @@ ENV BOOT2DOCKER_ID 1000
 ENV BOOT2DOCKER_GID 50
 
 ENV PHPMYADMIN_VERSION=5.0.2
+ENV SUPERVISOR_VERSION=4.2.0
 
 # Tweaks to give Apache/PHP write permissions to the app
 RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
@@ -28,9 +29,14 @@ RUN add-apt-repository -y ppa:ondrej/php && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
   apt-get update && \
   apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy upgrade && \
-  apt-get -y install postfix supervisor wget git apache2 php-xdebug libapache2-mod-php mysql-server php-mysql pwgen php-apcu php-gd php-xml php-mbstring php-gettext zip unzip php-zip curl php-curl && \
+  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php mysql-server php-mysql pwgen php-apcu php-gd php-xml php-mbstring php-gettext zip unzip php-zip curl php-curl && \
   apt-get -y autoremove && \
   echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+# Install supervisor 4
+RUN curl -L https://pypi.io/packages/source/s/supervisor/supervisor-${SUPERVISOR_VERSION}.tar.gz | tar xvz && \
+  cd supervisor-${SUPERVISOR_VERSION}/ && \
+  python3 setup.py install
 
 # Add image configuration and scripts
 ADD supporting_files/start-apache2.sh /start-apache2.sh
@@ -39,6 +45,7 @@ ADD supporting_files/run.sh /run.sh
 RUN chmod 755 /*.sh
 ADD supporting_files/supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
 ADD supporting_files/supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+ADD supporting_files/supervisord.conf /etc/supervisor/supervisord.conf
 ADD supporting_files/mysqld_innodb.cnf /etc/mysql/conf.d/mysqld_innodb.cnf
 
 # Remove pre-installed database

--- a/1804/Dockerfile
+++ b/1804/Dockerfile
@@ -12,6 +12,7 @@ ENV BOOT2DOCKER_ID 1000
 ENV BOOT2DOCKER_GID 50
 
 ENV PHPMYADMIN_VERSION=5.0.2
+ENV SUPERVISOR_VERSION=4.2.0
 
 # Tweaks to give Apache/PHP write permissions to the app
 RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
@@ -27,9 +28,14 @@ RUN add-apt-repository -y ppa:ondrej/php && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install postfix supervisor wget git apache2 php-xdebug libapache2-mod-php mysql-server php-mysql pwgen php-apcu php-gd php-xml php-mbstring php-gettext zip unzip php-zip curl php-curl && \
+  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php mysql-server php-mysql pwgen php-apcu php-gd php-xml php-mbstring php-gettext zip unzip php-zip curl php-curl && \
   apt-get -y autoremove && \
   echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+# Install supervisor 4
+RUN curl -L https://pypi.io/packages/source/s/supervisor/supervisor-${SUPERVISOR_VERSION}.tar.gz | tar xvz && \
+  cd supervisor-${SUPERVISOR_VERSION}/ && \
+  python3 setup.py install
 
 # Add image configuration and scripts
 ADD supporting_files/start-apache2.sh /start-apache2.sh
@@ -38,6 +44,7 @@ ADD supporting_files/run.sh /run.sh
 RUN chmod 755 /*.sh
 ADD supporting_files/supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
 ADD supporting_files/supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+ADD supporting_files/supervisord.conf /etc/supervisor/supervisord.conf
 ADD supporting_files/mysqld_innodb.cnf /etc/mysql/conf.d/mysqld_innodb.cnf
 
 # Remove pre-installed database

--- a/supporting_files/start-mysqld.sh
+++ b/supporting_files/start-mysqld.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe
+exec /usr/local/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe

--- a/supporting_files/supervisord.conf
+++ b/supporting_files/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+
+[include]
+files=/etc/supervisor/conf.d/supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+
+; https://github.com/Supervisor/supervisor/issues/376#issuecomment-404385767
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock

--- a/tests/1604.sh
+++ b/tests/1604.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 source _helpers.sh
 
+waitForSupervisordProgram web1604-php7 apache2
+waitForSupervisordProgram web1604-php7 mysqld
+
 testimage 1604-php7 3010
 testmysql web1604-php7 3011

--- a/tests/1604.sh
+++ b/tests/1604.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source _helpers.sh
 
-waitForSupervisordProgram web1604-php7 apache2
-waitForSupervisordProgram web1604-php7 mysqld
+waitForSupervisordProcess web1604-php7 apache2
+waitForSupervisordProcess web1604-php7 mysqld
 
 testimage 1604-php7 3010
 testmysql web1604-php7 3011

--- a/tests/1804.sh
+++ b/tests/1804.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 source _helpers.sh
 
-waitForSupervisordProgram web1804-php7 apache2
-waitForSupervisordProgram web1804-php7 mysqld
+waitForSupervisordProcess web1804-php7 apache2
+waitForSupervisordProcess web1804-php7 mysqld
 
 testimage 1804-php7 3000
 testmysql web1804-php7 3001

--- a/tests/1804.sh
+++ b/tests/1804.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 source _helpers.sh
 
+waitForSupervisordProgram web1804-php7 apache2
+waitForSupervisordProgram web1804-php7 mysqld
+
 testimage 1804-php7 3000
 testmysql web1804-php7 3001

--- a/tests/_helpers.sh
+++ b/tests/_helpers.sh
@@ -27,11 +27,11 @@ function testmysql {
     checkstatus $?
 }
 
-function waitForSupervisordProgram {
-    false
-    while [ $? -ne 0 ]; do
-        sleep 5
+function waitForSupervisordProcess {
+    while true; do
         echo "=> Waiting for $2 on the service $1..."
         docker-compose -f ../docker-compose.test.yml -p ci exec $1 supervisorctl status $2
+        [ $? -ne 0 ] || break
+        sleep 5
     done
 }

--- a/tests/_helpers.sh
+++ b/tests/_helpers.sh
@@ -26,3 +26,12 @@ function testmysql {
     mysql -h 127.0.0.1 -P $2 -u admin -ppassword -e"quit"
     checkstatus $?
 }
+
+function waitForSupervisordProgram {
+    false
+    while [ $? -ne 0 ]; do
+        sleep 5
+        echo "=> Waiting for $2 on the service $1..."
+        docker-compose -f ../docker-compose.test.yml -p ci exec $1 supervisorctl status $2
+    done
+}

--- a/tests/expected/1604-php7.html
+++ b/tests/expected/1604-php7.html
@@ -45,7 +45,7 @@
 OS: Ubuntu 16.04.6 LTS<br/>
 Apache: Apache/2.4.18 (Ubuntu)<br/>
 MySQL Version: 5.7.30-0ubuntu0.16.04.1-log<br/>
-PHP Version: 7.4.7<br/>
+PHP Version: 7.4.8<br/>
 phpMyAdmin Version: 5.0.2            </pre>
         </section>
     </div>

--- a/tests/expected/1604-php7.html
+++ b/tests/expected/1604-php7.html
@@ -45,7 +45,7 @@
 OS: Ubuntu 16.04.6 LTS<br/>
 Apache: Apache/2.4.18 (Ubuntu)<br/>
 MySQL Version: 5.7.30-0ubuntu0.16.04.1-log<br/>
-PHP Version: 7.4.6<br/>
+PHP Version: 7.4.7<br/>
 phpMyAdmin Version: 5.0.2            </pre>
         </section>
     </div>

--- a/tests/expected/1804-php7.html
+++ b/tests/expected/1804-php7.html
@@ -45,7 +45,7 @@
 OS: Ubuntu 18.04.4 LTS<br/>
 Apache: Apache/2.4.29 (Ubuntu)<br/>
 MySQL Version: 5.7.30-0ubuntu0.18.04.1-log<br/>
-PHP Version: 7.4.7<br/>
+PHP Version: 7.4.8<br/>
 phpMyAdmin Version: 5.0.2            </pre>
         </section>
     </div>

--- a/tests/expected/1804-php7.html
+++ b/tests/expected/1804-php7.html
@@ -45,7 +45,7 @@
 OS: Ubuntu 18.04.4 LTS<br/>
 Apache: Apache/2.4.29 (Ubuntu)<br/>
 MySQL Version: 5.7.30-0ubuntu0.18.04.1-log<br/>
-PHP Version: 7.4.6<br/>
+PHP Version: 7.4.7<br/>
 phpMyAdmin Version: 5.0.2            </pre>
         </section>
     </div>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,8 +3,6 @@ source _helpers.sh
 
 echo
 echo "Testing mattrayner/lamp"
-echo "=> Sleeping to allow boot of containers"
-sleep 60
 
 if [ -d actual ]; then
      rm -R actual


### PR DESCRIPTION
## Issue

The current test relies on a constant timeout.

https://github.com/mattrayner/docker-lamp/blob/e1da0223c3362b65c3970719a7dd34f63ec3b024/tests/test.sh#L6-L7

However, if the computer's performance is weak, the test will fail.

``` console
$ docker-compose -f docker-compose.test.yml -p ci build; docker-compose -f docker-compose.test.yml -p ci up -d; cd tests && ./test.sh; echo "Exited with status code: $?";
...

Testing mattrayner/lamp
=> Sleeping to allow boot of containers

=> Testing 18.04 images
=> Querying image (1804-php7)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (52) Empty reply from server
=> Failed
Exited with status code: 52
$ docker-compose -f docker-compose.test.yml -p ci logs -f -t web1804-php7
...
web1804-php7_1  | 2020-06-21T05:00:46.778298476Z Updating for 7.4
web1804-php7_1  | 2020-06-21T05:01:22.438296883Z => An empty or uninitialized MySQL volume is detected in /var/lib/mysql
web1804-php7_1  | 2020-06-21T05:01:22.439023678Z => Installing MySQL ...
...
web1804-php7_1  | 2020-06-21T05:01:52.906983590Z 2020-06-21 05:01:52,906 INFO supervisord started with pid 1
web1804-php7_1  | 2020-06-21T05:01:53.911097997Z 2020-06-21 05:01:53,910 INFO spawned: 'mysqld' with pid 502
web1804-php7_1  | 2020-06-21T05:01:53.922197420Z 2020-06-21 05:01:53,921 INFO spawned: 'apache2' with pid 503
web1804-php7_1  | 2020-06-21T05:01:55.260629128Z 2020-06-21 05:01:55,260 INFO success: mysqld entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
web1804-php7_1  | 2020-06-21T05:01:55.261457922Z 2020-06-21 05:01:55,261 INFO success: apache2 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```

As you can see, Apache and MySQL took 69 seconds to start.

## Solution

### Upgrade supervisor

Due to this image uses `supervisord` to manage Apache and MySQL, we should check their status through `supervisorctl`. Unfortunately, the supervisor (is version 3 in [16.04](https://packages.ubuntu.com/xenial/supervisor) and [18.04](https://packages.ubuntu.com/bionic/supervisor)) from Ubuntu has some problems so that it cannot return a non-zero value when the specific supervisord process is not running, so we have to use supervisor 4 (see https://github.com/Supervisor/supervisor/issues/24#issuecomment-226188127 , [Running supervisorctl # Running Supervisor &mdash; Supervisor 4.2.0 documentation](http://supervisord.org/running.html#running-supervisorctl) and [Changelog &mdash; Supervisor 4.2.0 documentation](http://supervisord.org/changes.html)).

supervisor 3

``` console
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisord -v
3.3.1
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisorctl status apache2
apache2                          RUNNING   pid 503, uptime 0:54:21
$ echo $?
0
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisorctl stop apache2
apache2: stopped
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisorctl status apache2
apache2                          STOPPED   Jun 20 03:35 PM
$ echo $?
0
```

supervisor 4

``` console
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisord -v
4.2.0
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisorctl status apache2
apache2                          RUNNING   pid 502, uptime 0:06:15
$ echo $?
0
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisorctl stop apache2
apache2: stopped
$ docker-compose -f docker-compose.test.yml -p ci exec web1804-php7 supervisorctl status apache2
apache2                          STOPPED   Jun 20 03:48 PM
$ echo $?
3
```

### Installation

[The installation of supervisor 4](http://supervisord.org/installing.html#installing-to-a-system-with-internet-access) needs `python-pip`. `python-pip` and its dependencies are too heavy to be packaged into the image, so I downloaded [the tarball from PyPI](https://pypi.org/project/supervisor/#files) and installed it through `python3`.

PS: [In Ubuntu 20.04, supervisor 4 is provided](https://packages.ubuntu.com/focal/supervisor). If you want to build a 20.04 image in the future, installing supervisor directly is enough.

### Configuration

`/etc/supervisor/supervisord.conf` [is needed in supervisor 4](http://supervisord.org/configuration.html#configuration-file). In order to use `supervisorctl` normally, I copied the code from https://github.com/Supervisor/supervisor/issues/376#issuecomment-404385767 .

Since supervisor 4 does not search for files in `/etc/supervisor/conf.d/*` by default, I added the `[include]` section to include the existing configuration files.
