### PR TITLE
Add project name "ci" to "docker-compose down" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ run-tests:
 	cd tests && ./test.sh
 
 clean:
-	docker-compose -f docker-compose.test.yml down
+	docker-compose -f docker-compose.test.yml -p ci down


### PR DESCRIPTION
To shutdown and remove the containers which are created by "docker-compose up" as expected.