### PR TITLE
update expected mysql and php versions so tests are passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ There are 3 main 'versions' of the docker image. The table below shows the diffe
 Component | `latest-1404` | `latest-1604` | `latest-1804`
 ---|---|---|---
 [Apache][apache] | `2.4.7` | `2.4.18` | `2.4.29`
-[MySQL][mysql] | `5.5.62` | `5.7.30` | `5.7.30`
-[PHP][php] | `7.3.3` | `7.4.6` | `7.4.6`
+[MySQL][mysql] | `5.5.62` | `5.7.31` | `5.7.31`
+[PHP][php] | `7.3.3` | `7.4.9` | `7.4.9`
 [phpMyAdmin][phpmyadmin] | `4.8.5` | `5.0.2` | `5.0.2`
 
 

--- a/tests/expected/1604-php7.html
+++ b/tests/expected/1604-php7.html
@@ -42,10 +42,10 @@
         </article>
         <section>
             <pre>
-OS: Ubuntu 16.04.6 LTS<br/>
+OS: Ubuntu 16.04.7 LTS<br/>
 Apache: Apache/2.4.18 (Ubuntu)<br/>
-MySQL Version: 5.7.30-0ubuntu0.16.04.1-log<br/>
-PHP Version: 7.4.8<br/>
+MySQL Version: 5.7.31-0ubuntu0.16.04.1-log<br/>
+PHP Version: 7.4.9<br/>
 phpMyAdmin Version: 5.0.2            </pre>
         </section>
     </div>

--- a/tests/expected/1804-php7.html
+++ b/tests/expected/1804-php7.html
@@ -42,10 +42,10 @@
         </article>
         <section>
             <pre>
-OS: Ubuntu 18.04.4 LTS<br/>
+OS: Ubuntu 18.04.5 LTS<br/>
 Apache: Apache/2.4.29 (Ubuntu)<br/>
-MySQL Version: 5.7.30-0ubuntu0.18.04.1-log<br/>
-PHP Version: 7.4.8<br/>
+MySQL Version: 5.7.31-0ubuntu0.18.04.1-log<br/>
+PHP Version: 7.4.9<br/>
 phpMyAdmin Version: 5.0.2            </pre>
         </section>
     </div>


### PR DESCRIPTION
When running the tests as described in the readme, I ended up with newer versions for both mysql and php, which failed the test. I adjusted the tests and the readme accordingly. Tests are then passed succesfully again.