### PR TITLE
Ubuntu 18.04 with PHP 7.1

### DIFF
--- a/1804-php71/Dockerfile
+++ b/1804-php71/Dockerfile
@@ -28,7 +28,7 @@ RUN add-apt-repository -y ppa:ondrej/php && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php7.1 php7.1-mysql pwgen php7.1-gd php7.1-xml php7.1-mbstring zip unzip php7.1-zip curl php7.1-curl && \
+  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php7.1 mysql-server php7.1-mysql pwgen php-apcu php7.1-gd php7.1-xml php7.1-mbstring zip unzip php7.1-zip curl php7.1-curl && \
   apt-get -y autoremove && \
   echo "ServerName localhost" >> /etc/apache2/apache2.conf
 

--- a/1804-php71/Dockerfile
+++ b/1804-php71/Dockerfile
@@ -28,7 +28,7 @@ RUN add-apt-repository -y ppa:ondrej/php && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php7.1 mysql-server php7.1-mysql pwgen php-apcu php7.1-gd php7.1-xml php7.1-mbstring zip unzip php7.1-zip curl php7.1-curl && \
+  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php7.1 mysql-server php7.1-mysql pwgen php-apcu php7.1-gd php7.1-xml php7.1-mbstring php7.1-gettext zip unzip php7.1-zip curl php7.1-curl && \
   apt-get -y autoremove && \
   echo "ServerName localhost" >> /etc/apache2/apache2.conf
 

--- a/1804-php71/Dockerfile
+++ b/1804-php71/Dockerfile
@@ -1,0 +1,86 @@
+FROM phusion/baseimage:0.11
+MAINTAINER Matthew Rayner <hello@rayner.io>
+ENV REFRESHED_AT 2019-06-11
+
+# based on dgraziotin/lamp
+# MAINTAINER Daniel Graziotin <daniel@ineed.coffee>
+
+ENV DOCKER_USER_ID 501 
+ENV DOCKER_USER_GID 20
+
+ENV BOOT2DOCKER_ID 1000
+ENV BOOT2DOCKER_GID 50
+
+ENV PHPMYADMIN_VERSION=5.0.2
+ENV SUPERVISOR_VERSION=4.2.0
+
+# Tweaks to give Apache/PHP write permissions to the app
+RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
+    usermod -G staff www-data && \
+    useradd -r mysql && \
+    usermod -G staff mysql && \
+    groupmod -g $(($BOOT2DOCKER_GID + 10000)) $(getent group $BOOT2DOCKER_GID | cut -d: -f1) && \
+    groupmod -g ${BOOT2DOCKER_GID} staff
+
+# Install packages
+ENV DEBIAN_FRONTEND noninteractive
+RUN add-apt-repository -y ppa:ondrej/php && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php mysql-server php7.1-mysql pwgen php-apcu php7.1-gd php7.1-xml php7.1-mbstring php-gettext zip unzip php7.1-zip curl php7.1-curl && \
+  apt-get -y autoremove && \
+  echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+# Install supervisor 4
+RUN curl -L https://pypi.io/packages/source/s/supervisor/supervisor-${SUPERVISOR_VERSION}.tar.gz | tar xvz && \
+  cd supervisor-${SUPERVISOR_VERSION}/ && \
+  python3 setup.py install
+
+# Add image configuration and scripts
+ADD supporting_files/start-apache2.sh /start-apache2.sh
+ADD supporting_files/start-mysqld.sh /start-mysqld.sh
+ADD supporting_files/run.sh /run.sh
+RUN chmod 755 /*.sh
+ADD supporting_files/supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
+ADD supporting_files/supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+ADD supporting_files/supervisord.conf /etc/supervisor/supervisord.conf
+ADD supporting_files/mysqld_innodb.cnf /etc/mysql/conf.d/mysqld_innodb.cnf
+
+# Remove pre-installed database
+RUN rm -rf /var/lib/mysql
+
+# Add MySQL utils
+ADD supporting_files/create_mysql_users.sh /create_mysql_users.sh
+
+# Add phpmyadmin
+RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz
+RUN tar xfvz /tmp/phpmyadmin.tar.gz -C /var/www
+RUN ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin
+RUN mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php
+
+# Add composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    php composer-setup.php && \
+    php -r "unlink('composer-setup.php');" && \
+    mv composer.phar /usr/local/bin/composer
+
+ENV MYSQL_PASS:-$(pwgen -s 12 1)
+# config to enable .htaccess
+ADD supporting_files/apache_default /etc/apache2/sites-available/000-default.conf
+RUN a2enmod rewrite
+
+# Configure /app folder with sample app
+RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
+ADD app/ /app
+
+#Environment variables to configure php
+ENV PHP_UPLOAD_MAX_FILESIZE 10M
+ENV PHP_POST_MAX_SIZE 10M
+ENV PHP_VERSION 7.4
+
+# Add volumes for the app and MySql
+VOLUME  ["/var/lib/mysql", "/app" ]
+
+EXPOSE 80 3306
+CMD ["/run.sh"]

--- a/1804-php71/Dockerfile
+++ b/1804-php71/Dockerfile
@@ -28,7 +28,7 @@ RUN add-apt-repository -y ppa:ondrej/php && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php mysql-server php7.1-mysql pwgen php-apcu php7.1-gd php7.1-xml php7.1-mbstring php-gettext zip unzip php7.1-zip curl php7.1-curl && \
+  apt-get -y install python3-setuptools wget git apache2 libapache2-mod-php7.1 php7.1-mysql pwgen php7.1-gd php7.1-xml php7.1-mbstring zip unzip php7.1-zip curl php7.1-curl && \
   apt-get -y autoremove && \
   echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
@@ -77,7 +77,7 @@ ADD app/ /app
 #Environment variables to configure php
 ENV PHP_UPLOAD_MAX_FILESIZE 10M
 ENV PHP_POST_MAX_SIZE 10M
-ENV PHP_VERSION 7.4
+ENV PHP_VERSION 7.1
 
 # Add volumes for the app and MySql
 VOLUME  ["/var/lib/mysql", "/app" ]

--- a/1804-php71/Dockerfile
+++ b/1804-php71/Dockerfile
@@ -28,7 +28,7 @@ RUN add-apt-repository -y ppa:ondrej/php && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install python3-setuptools wget git apache2 libapache2-mod-php7.1 php7.1-mysql pwgen php7.1-gd php7.1-xml php7.1-mbstring zip unzip php7.1-zip curl php7.1-curl && \
+  apt-get -y install postfix python3-setuptools wget git apache2 php-xdebug libapache2-mod-php7.1 php7.1-mysql pwgen php7.1-gd php7.1-xml php7.1-mbstring zip unzip php7.1-zip curl php7.1-curl && \
   apt-get -y autoremove && \
   echo "ServerName localhost" >> /etc/apache2/apache2.conf
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,3 +15,12 @@ web1604-php7:
   ports:
     - "3010:80"
     - "3011:3306"
+
+web1804-php71:
+  build: .
+  dockerfile: ./1804-php71/Dockerfile
+  environment:
+    - MYSQL_ADMIN_PASS=password
+  ports:
+    - "3020:80"
+    - "3021:3306"

--- a/tests/1804-71.sh
+++ b/tests/1804-71.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+source _helpers.sh
+
+waitForSupervisordProcess web1804-php71 apache2
+waitForSupervisordProcess web1804-php71 mysqld
+
+testimage 1804-php71 3000
+testmysql web1804-php71 3001

--- a/tests/1804-71.sh
+++ b/tests/1804-71.sh
@@ -4,5 +4,5 @@ source _helpers.sh
 waitForSupervisordProcess web1804-php71 apache2
 waitForSupervisordProcess web1804-php71 mysqld
 
-testimage 1804-php71 3000
-testmysql web1804-php71 3001
+testimage 1804-php71 3020
+testmysql web1804-php71 3021

--- a/tests/expected/1804-php71.html
+++ b/tests/expected/1804-php71.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang=en>
+<head>
+    <meta charset=utf-8>
+    <title>Hello World from Docker-LAMP</title>
+
+    <style>
+        @import 'https://fonts.googleapis.com/css?family=Montserrat|Raleway|Source+Code+Pro';
+
+        body { font-family: 'Raleway', sans-serif; }
+        h2 { font-family: 'Montserrat', sans-serif; }
+        pre {
+            font-family: 'Source Code Pro', monospace;
+
+            padding: 16px;
+            overflow: auto;
+            font-size: 85%;
+            line-height: 1.45;
+            background-color: #f7f7f7;
+            border-radius: 3px;
+
+            word-wrap: normal;
+        }
+
+        .container {
+            max-width: 1024px;
+            width: 100%;
+            margin: 0 auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <img src="https://cdn.rawgit.com/mattrayner/docker-lamp/831976c022782e592b7e2758464b2a9efe3da042/docs/logo.svg" alt="Docker LAMP logo" />
+            <h2>Welcome to <a href="https://github.com/mattrayner/docker-lamp" target="_blank">Docker-Lamp</a> a.k.a mattrayner/lamp</h2>
+        </header>
+        <article>
+            <p>
+                For documentation, <a href="https://github.com/mattrayner/docker-lamp" target="_blank">click here</a>.
+            </p>
+        </article>
+        <section>
+            <pre>
+OS: Ubuntu 18.04.4 LTS<br/>
+Apache: Apache/2.4.29 (Ubuntu)<br/>
+MySQL Version: 5.7.30-0ubuntu0.18.04.1-log<br/>
+PHP Version: 7.4.8<br/>
+phpMyAdmin Version: 5.0.2            </pre>
+        </section>
+    </div>
+</body>
+</html>

--- a/tests/expected/1804-php71.html
+++ b/tests/expected/1804-php71.html
@@ -42,10 +42,10 @@
         </article>
         <section>
             <pre>
-OS: Ubuntu 18.04.4 LTS<br/>
+OS: Ubuntu 18.04.5 LTS<br/>
 Apache: Apache/2.4.29 (Ubuntu)<br/>
-MySQL Version: 5.7.30-0ubuntu0.18.04.1-log<br/>
-PHP Version: 7.4.8<br/>
+MySQL Version: 5.7.31-0ubuntu0.18.04.1-log<br/>
+PHP Version: 7.1.33-17+ubuntu18.04.1+deb.sury.org+1<br/>
 phpMyAdmin Version: 5.0.2            </pre>
         </section>
     </div>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -15,3 +15,6 @@ echo "=> Testing 18.04 images"
 
 echo "=> Testing 16.04 images"
 . 1604.sh
+
+echo "=> Testing 18.04 with php 7.1 images"
+. 1804-php72.sh

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -17,4 +17,4 @@ echo "=> Testing 16.04 images"
 . 1604.sh
 
 echo "=> Testing 18.04 with php 7.1 images"
-. 1804-php72.sh
+. 1804-71.sh


### PR DESCRIPTION
Hi, I've built this image by copying the existing 1804 dockerfile, and modifying the apt-get install to the respective packages. It seems to be working, but I'm very aware that I might have missed important details.

I think installing it via metapackages might also be an option, but I wanted to remain as close to the approach used as possible.

I'm thankful for any feedback, even if it means the code won't be merged, so I'll know I would need to make a permanent fork :)

Note: The tests will be failing, as 1804 and 1604 are getting different versions as referenced in #105.
The test for my image alone was passed.