### PR TITLE
Support for php 8 and mysql 8 on ubuntu 20.04

### DIFF
--- a/2004/Dockerfile
+++ b/2004/Dockerfile
@@ -1,0 +1,86 @@
+FROM phusion/baseimage:focal-1.0.0
+ENV REFRESHED_AT 2019-06-11
+
+# based on dgraziotin/lamp
+# MAINTAINER Daniel Graziotin <daniel@ineed.coffee>
+
+ENV DOCKER_USER_ID 501 
+ENV DOCKER_USER_GID 20
+
+ENV BOOT2DOCKER_ID 1000
+ENV BOOT2DOCKER_GID 50
+
+ENV PHPMYADMIN_VERSION=5.0.2
+ENV SUPERVISOR_VERSION=4.2.0
+
+# Tweaks to give Apache/PHP write permissions to the app
+RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
+    usermod -G staff www-data && \
+    useradd -r mysql && \
+    usermod -G staff mysql && \
+    groupmod -g $(($BOOT2DOCKER_GID + 10000)) $(getent group $BOOT2DOCKER_GID | cut -d: -f1) && \
+    groupmod -g ${BOOT2DOCKER_GID} staff
+
+# Install packages
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt install -y software-properties-common
+RUN add-apt-repository -y ppa:ondrej/php && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get -y install  python3-setuptools wget git apache2 php-xdebug libapache2-mod-php mysql-server php-mysql pwgen php-apcu php-gd php-xml php-mbstring zip unzip php-zip curl php-curl && \
+  apt-get -y autoremove && \
+  echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+# Install supervisor 4
+RUN curl -L https://pypi.io/packages/source/s/supervisor/supervisor-${SUPERVISOR_VERSION}.tar.gz | tar xvz && \
+  cd supervisor-${SUPERVISOR_VERSION}/ && \
+  python3 setup.py install
+
+# Add image configuration and scripts
+ADD supporting_files/start-apache2.sh /start-apache2.sh
+ADD supporting_files/start-mysqld.sh /start-mysqld.sh
+ADD supporting_files/run.sh /run.sh
+RUN chmod 755 /*.sh
+ADD supporting_files/supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
+ADD supporting_files/supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+ADD supporting_files/supervisord.conf /etc/supervisor/supervisord.conf
+ADD supporting_files/mysqld_innodb.cnf /etc/mysql/conf.d/mysqld_innodb.cnf
+
+# Remove pre-installed database
+RUN rm -rf /var/lib/mysql
+
+# Add MySQL utils
+ADD supporting_files/create_mysql_users.sh /create_mysql_users.sh
+
+# Add phpmyadmin
+RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz
+RUN tar xfvz /tmp/phpmyadmin.tar.gz -C /var/www
+RUN ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin
+RUN mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php
+
+# Add composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    php composer-setup.php && \
+    php -r "unlink('composer-setup.php');" && \
+    mv composer.phar /usr/local/bin/composer
+
+ENV MYSQL_PASS:-$(pwgen -s 12 1)
+# config to enable .htaccess
+ADD supporting_files/apache_default /etc/apache2/sites-available/000-default.conf
+RUN a2enmod rewrite
+
+# Configure /app folder with sample app
+RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
+ADD app/ /app
+
+#Environment variables to configure php
+ENV PHP_UPLOAD_MAX_FILESIZE 10M
+ENV PHP_POST_MAX_SIZE 10M
+ENV PHP_VERSION 8.0
+
+# Add volumes for the app and MySql
+VOLUME  ["/var/lib/mysql", "/app" ]
+
+EXPOSE 80 3306
+CMD ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![Docker-LAMP][logo]
-Docker-LAMP is a set of docker images that include the phusion baseimage (16.04 and 18.04 varieties), along with a LAMP stack ([Apache][apache], [MySQL][mysql] and [PHP][php]) all in one handy package.
+Docker-LAMP is a set of docker images that include the phusion baseimage (16.04, 18.04 and 20.04 varieties), along with a LAMP stack ([Apache][apache], [MySQL][mysql] and [PHP][php]) all in one handy package.
 
-With Ubuntu **18.04** amd **16.04** images on the `latest-1804` and `latest-1604` tags, Docker-LAMP is flexible enough to use with all of your LAMP projects.
+With Ubuntu **18.04**, **16.04** amd **20.04** images on the `latest-1804`, `latest-1604` and `latest-2004` tags, Docker-LAMP is flexible enough to use with all of your LAMP projects.
 
 [![Build Status][shield-build-status]][info-build-status]
 [![Docker Hub][shield-docker-hub]][info-docker-hub]
@@ -55,18 +55,21 @@ Designed to be a single interface that just 'gets out of your way', and works on
 
 There are 3 main 'versions' of the docker image. The table below shows the different tags you can use, along with the PHP, MySQL and Apache versions that come with it.
 
-Component | `latest-1404` | `latest-1604` | `latest-1804`
----|---|---|---
-[Apache][apache] | `2.4.7` | `2.4.18` | `2.4.29`
-[MySQL][mysql] | `5.5.62` | `5.7.30` | `5.7.30`
-[PHP][php] | `7.3.3` | `7.4.6` | `7.4.6`
-[phpMyAdmin][phpmyadmin] | `4.8.5` | `5.0.2` | `5.0.2`
+Component | `latest-1404` | `latest-1604` | `latest-1804` | `latest-2004`
+---|---|---|---|---
+[Apache][apache] | `2.4.7` | `2.4.18` | `2.4.29` | `2.4.41`
+[MySQL][mysql] | `5.5.62` | `5.7.30` | `5.7.30` | `8.0.26`
+[PHP][php] | `7.3.3` | `7.4.6` | `7.4.6` | `8.0.10`
+[phpMyAdmin][phpmyadmin] | `4.8.5` | `5.0.2` | `5.0.2` | `5.0.2`
 
 
 ## Using the image
 ### On the command line
 This is the quickest way
 ```bash
+# Launch a 20.04 based image
+docker run -p "80:80" -v ${PWD}/app:/app mattrayner/lamp:latest-2004
+
 # Launch a 18.04 based image
 docker run -p "80:80" -v ${PWD}/app:/app mattrayner/lamp:latest-1804
 


### PR DESCRIPTION
I create a simple docker file to support PHP8, mysql 8 on ubuntu 20.04 based on your code.
I'm using your container for my project and created this for laravel 8 projects.