### PR TITLE
Add support for MySQL initialization script

### DIFF
--- a/1804/Dockerfile
+++ b/1804/Dockerfile
@@ -55,7 +55,7 @@ ADD supporting_files/supervisord.conf /etc/supervisor/supervisord.conf
 RUN rm -rf /var/lib/mysql
 
 # Add MySQL utils
-ADD supporting_files/create_mysql_users.sh /create_mysql_users.sh
+ADD supporting_files/mysql_init.sh /mysql_init.sh
 
 # Add phpmyadmin
 RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz

--- a/2004/Dockerfile
+++ b/2004/Dockerfile
@@ -55,7 +55,7 @@ ADD supporting_files/supervisord.conf /etc/supervisor/supervisord.conf
 RUN rm -rf /var/lib/mysql
 
 # Add MySQL utils
-ADD supporting_files/create_mysql_users.sh /create_mysql_users.sh
+ADD supporting_files/mysql_init.sh /mysql_init.sh
 
 # Add phpmyadmin
 RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ With Ubuntu **20.04** and **18.04** images on the `latest-2004` and `latest-1804
     - [Creating a database](#creating-a-database)
       - [PHPMyAdmin](#phpmyadmin)
       - [Command Line](#command-line)
+      - [Initialization script](#initialization-script)
+    - [SQL initialization script](#sql-initialization-script)
 - [Adding your own content](#adding-your-own-content)
   - [Adding your app](#adding-your-app)
   - [Persisting your MySQL](#persisting-your-mysql)
@@ -103,10 +105,11 @@ When you first run the image you'll see a message showing your `admin` user's pa
 If you need this login later, you can run `docker logs CONTAINER_ID` and you should see it at the top of the log.
 
 #### Creating a database
-So your application needs a database - you have two options...
+So your application needs a database - you have three options:
 
 1. PHPMyAdmin
 2. Command line
+3. Initialization script
 
 ##### PHPMyAdmin
 Docker-LAMP comes pre-installed with phpMyAdmin available from `http://DOCKER_ADDRESS/phpmyadmin`.
@@ -119,6 +122,19 @@ First, get the ID of your running container with `docker ps`, then run the below
 docker exec CONTAINER_ID  mysql -uroot -e "create database DATABASE_NAME"
 ```
 
+##### Initialization script
+See the [SQL initialization script section](#sql-initialization-script) for details.
+
+#### SQL initialization script
+Optionally, you can provide a SQL script which will run immediately after MySQL has been installed and configured, allowing you to run custom SQL e.g. to create a database, users or insert custom data.
+
+Please note that **the SQL initialization script runs only at the container first startup**. The script won't run if MySQL has already been configured (i.e. if the `/var/lib/mysql` contains initialized MySQL data).
+
+The below command will run the docker image `mattrayner/lamp:latest` interactively, exposing port `80` on the host machine with port `80` on the docker container. It will also create a volume linking the `script.sql` file within your current folder to the `/db/mysql_init.sql` file on the container. This is where the container expects the SQL initialization script to live.
+
+```bash
+docker run -i -t -p "80:80" -v ${PWD}/script.sql:/db/mysql_init.sql:ro mattrayner/lamp:latest
+```
 
 ## Adding your own content
 The 'easiest' way to add your own content to the lamp image is using Docker volumes. This will effectively 'sync' a particular folder on your machine with that on the docker container.

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ Optionally, you can provide a SQL script which will run immediately after MySQL 
 
 Please note that **the SQL initialization script runs only at the container first startup**. The script won't run if MySQL has already been configured (i.e. if the `/var/lib/mysql` contains initialized MySQL data).
 
-The below command will run the docker image `mattrayner/lamp:latest` interactively, exposing port `80` on the host machine with port `80` on the docker container. It will also create a volume linking the `script.sql` file within your current folder to the `/db/mysql_init.sql` file on the container. This is where the container expects the SQL initialization script to live.
+The below command will run the docker image `mattrayner/lamp:latest` interactively, exposing port `80` on the host machine with port `80` on the docker container. It will also create a volume linking the `script.sql` file within your current folder to the `/db/init.sql` file on the container. This is where the container expects the SQL initialization script to live.
 
 ```bash
-docker run -i -t -p "80:80" -v ${PWD}/script.sql:/db/mysql_init.sql:ro mattrayner/lamp:latest
+docker run -i -t -p "80:80" -v ${PWD}/script.sql:/db/init.sql:ro mattrayner/lamp:latest
 ```
 
 ## Adding your own content

--- a/supporting_files/mysql_init.sh
+++ b/supporting_files/mysql_init.sh
@@ -39,6 +39,12 @@ if [ "$CREATE_MYSQL_USER" = true ]; then
     mysql -uroot -e "GRANT ALL PRIVILEGES ON ${_userdb}.* TO '${_user}'@'%'"
 fi
 
+if [[ -e /db/mysql_init.sql ]]; then
+    echo "=> Initializing the database"
+
+    mysql -uroot < /db/mysql_init.sql
+fi
+
 echo "=> Done!"
 
 echo "========================================================================"

--- a/supporting_files/mysql_init.sh
+++ b/supporting_files/mysql_init.sh
@@ -39,10 +39,10 @@ if [ "$CREATE_MYSQL_USER" = true ]; then
     mysql -uroot -e "GRANT ALL PRIVILEGES ON ${_userdb}.* TO '${_user}'@'%'"
 fi
 
-if [[ -e /db/mysql_init.sql ]]; then
+if [[ -e /db/init.sql ]]; then
     echo "=> Initializing the database"
 
-    mysql -uroot < /db/mysql_init.sql
+    mysql -uroot < /db/init.sql
 fi
 
 echo "=> Done!"

--- a/supporting_files/run.sh
+++ b/supporting_files/run.sh
@@ -106,7 +106,7 @@ if [[ ! -d $VOLUME_HOME/mysql ]]; then
     fi
 
     echo "=> Done!"
-    /create_mysql_users.sh
+    /mysql_init.sh
 else
     echo "=> Using an existing volume of MySQL"
 fi


### PR DESCRIPTION
Hi there,

First of all thank you so much for developing such a useful set of docker images. This project makes setting up the LAMP stack a breeze! 🎉 

While using your images, I needed not only to provide a custom app to the web server, but also to initialize a database with custom data, prior to the container's first boot. This includes multiple databases, tables, users etc. 

With this PR I'm adding support for a MySQL initialization script, which can be optionally provided by the user as a volume mount to `/db/init.sql`. In my opinion such solution provides the most flexible way to allow users to initialize the MySQL instance, custom-tailored to their specific needs.

The SQL script will be executed only on the container first run, or more generally, if `/var/lib/mysql` doesn't contain initialized data.

I successfully tested my changes on `docker-lamp_web2004-php8:latest`; however, I wasn't able to run the one-line testing command without errors. I also noticed that the testing command fails even when run directly on the `master` branch.

I edited relevant sections in the docs as well, adding a description of this new feature.

Hope you'll find my contribution valuable for the project. I'd be happy to help if you need additional information or you'd like to suggest further changes. :) 

Thank you for your precious time and for maintaining such a cool project!