### PR TITLE
Fix: .htaccess now working in /var/www/html

### DIFF
--- a/supporting_files/apache_default
+++ b/supporting_files/apache_default
@@ -10,6 +10,10 @@
                 allow from all
         </Directory>
 
+	<Directory "/var/www/html">
+                AllowOverride All
+        </Directory>
+
         Alias /phpmyadmin /var/www/phpmyadmin
         <Directory /phpmyadmin>
                 Options Indexes FollowSymLinks MultiViews


### PR DESCRIPTION
When I was using your docker setup I noticed my .htaccess file was not being processed. I added a couple of lines in the container to /etc/apache2/sites-enabled/000-default.conf which fixed the issue